### PR TITLE
Improved CUDA check, added MPS (Apple silicone) check

### DIFF
--- a/p1ch2/1_making_sure_things_work.ipynb
+++ b/p1ch2/1_making_sure_things_work.ipynb
@@ -17,7 +17,7 @@
     {
      "data": {
       "text/plain": [
-       "'1.0.0'"
+       "'2.5.1'"
       ]
      },
      "execution_count": 2,
@@ -75,11 +75,18 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUDA is not available.\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
        "tensor([[2., 2., 2.],\n",
        "        [2., 2., 2.],\n",
-       "        [2., 2., 2.]], device='cuda:0')"
+       "        [2., 2., 2.]])"
       ]
      },
      "execution_count": 6,
@@ -88,17 +95,49 @@
     }
    ],
    "source": [
-    "a = a.to('cuda')\n",
-    "b = b.to('cuda')\n",
+    "if torch.cuda.is_available():\n",
+    "    print(\"CUDA is available!\")\n",
+    "    a = a.to('cuda')\n",
+    "    b = b.to('cuda')\n",
+    "else:\n",
+    "    print(\"CUDA is not available.\")\n",
     "a + b"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apple Silicon (MPS backend) is available!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[2., 2., 2.],\n",
+       "        [2., 2., 2.],\n",
+       "        [2., 2., 2.]], device='mps:0')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "if torch.backends.mps.is_available():\n",
+    "    print(\"Apple Silicon (MPS backend) is available!\")\n",
+    "    a = a.to('mps')\n",
+    "    b = b.to('mps')\n",
+    "else:\n",
+    "    print(\"Apple Silicon (MPS backend) is not available.\")\n",
+    "a + b\n"
+   ]
   }
  ],
  "metadata": {
@@ -117,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Check for CUDA availability before trying to move the tensors to the GPU. Add a check for the Apple Silicon (MPS) backend and try to use it if available.